### PR TITLE
Change npm package name to agenticchat

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,29 +67,29 @@ Basic usage:
 # Default: JSON array output and exit (perfect for automation)
 npm run cli
 # or
-agentchat
+agenticchat
 
 # Interactive streaming mode (watch live events)
-agentchat --interactive
+agenticchat --interactive
 ```
 
 CLI options:
 
 ```bash
 # Default behavior - outputs JSON array and exits
-agentchat
-agentchat > events.json               # Save to file
-agentchat | jq '.[] | .content'       # Process with jq
+agenticchat
+agenticchat > events.json               # Save to file
+agenticchat | jq '.[] | .content'       # Process with jq
 
 # Interactive streaming mode
-agentchat --interactive               # Pretty-printed live stream
-agentchat --interactive --format json # JSON streaming with metadata
-agentchat --interactive --format compact # Compact live stream
+agenticchat --interactive               # Pretty-printed live stream
+agenticchat --interactive --format json # JSON streaming with metadata
+agenticchat --interactive --format compact # Compact live stream
 
 # Configuration options
-agentchat --max-events 100            # Fetch more events
-agentchat --no-profiles               # Skip profile fetching
-agentchat --help                      # Show help
+agenticchat --max-events 100            # Fetch more events
+agenticchat --no-profiles               # Skip profile fetching
+agenticchat --help                      # Show help
 ```
 
 ### Library Usage

--- a/cli.js
+++ b/cli.js
@@ -81,7 +81,7 @@ class AgentChatCLI {
 ${colors.bright}AgentChat CLI${colors.reset} - Stream #agentchat events from Nostr
 
 ${colors.bright}Usage:${colors.reset}
-  agentchat [options]
+  agenticchat [options]
 
 ${colors.bright}Default Behavior:${colors.reset}
   Outputs JSON array of events and exits after receiving all stored events.
@@ -96,12 +96,12 @@ ${colors.bright}Options:${colors.reset}
   -h, --help                Show this help message
 
 ${colors.bright}Examples:${colors.reset}
-  agentchat                             # Default: JSON array output and exit
-  agentchat > events.json               # Save events to file
-  agentchat | jq '.[] | .content'       # Process with jq
-  agentchat --interactive               # Watch live events (streaming mode)
-  agentchat --interactive --format pretty  # Pretty-printed live stream
-  agentchat --max-events 100            # Fetch more events
+  agenticchat                             # Default: JSON array output and exit
+  agenticchat > events.json               # Save events to file
+  agenticchat | jq '.[] | .content'       # Process with jq
+  agenticchat --interactive               # Watch live events (streaming mode)
+  agenticchat --interactive --format pretty  # Pretty-printed live stream
+  agenticchat --max-events 100            # Fetch more events
         `);
     }
 

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "agentchat",
+  "name": "agenticchat",
   "version": "0.0.1",
   "description": "Nostr event streaming for #agentchat with web and CLI interfaces",
   "type": "module",
   "main": "lib/agentchat.js",
   "bin": {
-    "agentchat": "./cli.js"
+    "agenticchat": "./cli.js"
   },
   "scripts": {
     "cli": "node cli.js",


### PR DESCRIPTION
## Summary

Changes the npm package name from `agentchat` to `agenticchat` to avoid naming conflicts on the npm registry. This addresses issue #9.

## Problem

The package name `agentchat` is already taken on npm, preventing us from publishing the package.

## ✨ Changes Made

### 📦 Package Configuration
- **Package name**: `agentchat` → `agenticchat`
- **Binary name**: `agentchat` → `agenticchat`
- **Global install**: `npm install -g agenticchat`

### 📚 Documentation Updates
- **CLI help**: Updated usage from `agentchat [options]` to `agenticchat [options]`
- **README examples**: All command examples now use `agenticchat`
- **Consistent branding**: Package name aligns with command name

## 🚀 New Usage

### Installation
```bash
npm install -g agenticchat
```

### Basic Usage
```bash
# Default: JSON output and exit
agenticchat

# Save to file
agenticchat > events.json

# Process with jq
agenticchat | jq '.[] | .content'

# Interactive streaming mode
agenticchat --interactive
```

## 📋 Files Changed

- `package.json`: Name and bin updated
- `cli.js`: Help text updated to show new command
- `README.md`: All examples updated to use new command

## ✅ Benefits

- **✅ Publishable**: Can now be published to npm
- **✅ Memorable**: "agenticchat" is clear and descriptive
- **✅ Consistent**: Command name matches package name
- **✅ Available**: Verified available on npm registry

## 🧪 Testing

- [x] CLI help shows correct command name
- [x] All README examples use new command
- [x] Package.json has correct name and binary
- [x] No functionality changes - only naming

Resolves #9

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>